### PR TITLE
Remove java support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ env:
     - secure: "MYuLy8HDRhoDlSvUbOy1qiPRtVdn6kaLNRq3cSjDmzIdr0AWnmGiIfpgRuDenvu+IG7foee0ahGIm9triHg2t4awkTSRnE6Sf4w5N7E7sOWOAc9BDwwNudlkB2lv+5CoLypWeNBC0K5XreWJWzeYr0vxBEH6S+H2LDazA/ESs6p8VHV2ZVu1F82DxKHTMtopHVRJ2k8jBjIPLxbSu3coJ8nGOwwAM/FPiKdMnBoFRS0hxBXHZkOMp/tehE2jSHRbEIrZThXpHBd4E6CoKhrgAhFwAtdSmjTOc9Wvg/5g0ZSO4eEXxvMc0pj43NnomtYx0ruwOsffh9rdOlRz/l+jhgw1hGvvhNaHbfHRNpzsy1CNhZQJ21C+FeVejg+f1TIanRPESTB1xBefviEnBIsJfjqY08dFUNwrQCsbN52miJlxWA1jWFfGLY182Kcq3KoshzfY54DoOowtUWSTRMAT0fHJ4rr84/HyGMv4uwjIUimN9EnnyWlMROwzJJWzOMkXwtPrc5CgMxzvtF8ZqeNqSmCpbbPdF7n8v0K/teZr4tf65vtof04NItA1VgWV142QJMGKHQzeMNvNKQNmdF6XtFTZOiHFoL0Ne18JS1WR44s073wO2WQj3I7jxd9b2bKZqVnKM25gmuLRCa7adcmxIuxssJUXUg41KxGwUQGZZHk="
 
 
-before install:
+before_install:
     - brew remove --force $(brew list)
 
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ About antlr
 
 Home: http://www.antlr2.org/
 
-Package license: http://www.antlr2.org/license.html
+Package license: BSD-3-clause and GPL-3.0 and Public Domain
 
 Feedstock license: BSD
 
-Summary: ANTLR, ANother Tool for Language Recognition, 2.7.7
+Summary: ANother Tool for Language Recognition (ANTLR)
 
 
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 
-if [[ $(uname) != Darwin ]]; then
-    yum install -y gcc-java
-fi
-
-./configure --enable-java \
+./configure --prefix=$PREFIX \
             --enable-cxx \
             --enable-python \
             --enable-csharp \
-            --prefix=$PREFIX
+            --disable-java \
 
 make
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,23 +9,24 @@ source:
         - CharScanner.patch
 
 build:
-    number: 0
+    number: 1
     skip: True  # [win]
+    skip: True  # [py3k]
 
 requirements:
     build:
-        - python >=2.7,<3
+        - python
     run:
         - python
 
 test:
     commands:
-        - antlr --help
+        - antlr-config --version
 
 about:
     home: http://www.antlr2.org/
-    license: http://www.antlr2.org/license.html
-    summary: ANTLR, ANother Tool for Language Recognition, 2.7.7
+    license: BSD-3-clause and GPL-3.0 and Public Domain
+    summary: ANother Tool for Language Recognition (ANTLR)
 
 extra:
     recipe-maintainers:


### PR DESCRIPTION
Closes #4 

The good news is that java support is not needed to get `nco`'s `ncap2` working. The bad news is that the `antlr` binary does need java at run time. However, this version of `antlr` is very old and we need it only for `ncap2`, so I believe we are OK without java.
