### PR TITLE
Argh clang...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
+      conda install --yes conda-build=1.21.9
 
 script:
   - conda build ./recipe

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@
 language: objective-c
 
 env:
-  matrix:
-    
-    - CONDA_PY=27
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "MYuLy8HDRhoDlSvUbOy1qiPRtVdn6kaLNRq3cSjDmzIdr0AWnmGiIfpgRuDenvu+IG7foee0ahGIm9triHg2t4awkTSRnE6Sf4w5N7E7sOWOAc9BDwwNudlkB2lv+5CoLypWeNBC0K5XreWJWzeYr0vxBEH6S+H2LDazA/ESs6p8VHV2ZVu1F82DxKHTMtopHVRJ2k8jBjIPLxbSu3coJ8nGOwwAM/FPiKdMnBoFRS0hxBXHZkOMp/tehE2jSHRbEIrZThXpHBd4E6CoKhrgAhFwAtdSmjTOc9Wvg/5g0ZSO4eEXxvMc0pj43NnomtYx0ruwOsffh9rdOlRz/l+jhgw1hGvvhNaHbfHRNpzsy1CNhZQJ21C+FeVejg+f1TIanRPESTB1xBefviEnBIsJfjqY08dFUNwrQCsbN52miJlxWA1jWFfGLY182Kcq3KoshzfY54DoOowtUWSTRMAT0fHJ4rr84/HyGMv4uwjIUimN9EnnyWlMROwzJJWzOMkXwtPrc5CgMxzvtF8ZqeNqSmCpbbPdF7n8v0K/teZr4tf65vtof04NItA1VgWV142QJMGKHQzeMNvNKQNmdF6XtFTZOiHFoL0Ne18JS1WR44s073wO2WQj3I7jxd9b2bKZqVnKM25gmuLRCa7adcmxIuxssJUXUg41KxGwUQGZZHk="
@@ -26,12 +23,10 @@ install:
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
-
-      conda config --set show_channel_urls true
-      conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
-      
+      conda config --set show_channel_urls true
+      conda install --yes --quiet conda-forge-build-setup
+      source run_conda_forge_build_setup
 
 script:
   - conda build ./recipe

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Package license: BSD-3-clause and GPL-3.0 and Public Domain
 
 Feedstock license: BSD 3-Clause
 
-Summary: ANother Tool for Language Recognition (ANTLR)
+Summary: ANother Tool for Language Recognition (ANTLR).
 
 
 
@@ -38,7 +38,7 @@ About conda-forge
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the
-conda-forge GitHub organization. The conda-forge organization contains one repository 
+conda-forge GitHub organization. The conda-forge organization contains one repository
 for each of the installable packages. Such a repository is known as a *feedstock*.
 
 A feedstock is made up of a conda recipe (the instructions on what and how to build
@@ -71,7 +71,7 @@ Current build status
 ====================
 
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/antlr-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/antlr-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/antlr-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/antlr-feedstock) 
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/antlr-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/antlr-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/antlr-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/antlr-feedstock/branch/master)
 
 Current release info
@@ -92,7 +92,7 @@ install and use.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string). 
+   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
    the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
    back to 0.

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -40,6 +40,7 @@ conda clean --lock
 
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
+conda install --yes conda-build=1.21.9
 
 # Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,6 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
-
  - defaults # As we need conda-build
 
 conda-build:
@@ -39,14 +38,10 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
-conda update --yes --all
-conda install --yes conda-build
-conda info
+conda install --yes --quiet conda-forge-build-setup
+source run_conda_forge_build_setup
 
 # Embarking on 1 case(s).
-    set -x
-    export CONDA_PY=27
-    set +x
     conda build /recipe_root --quiet || exit 1
     /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
 EOF

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 
+if [ $(uname) == Darwin ]; then
+    export CC=clang
+    export CXX=clang++
+    export MACOSX_DEPLOYMENT_TARGET="10.9"
+    export CXXFLAGS="-stdlib=libc++ $CXXFLAGS"
+    export CXXFLAGS="$CXXFLAGS -stdlib=libc++"
+fi
+
 ./configure --prefix=$PREFIX \
             --enable-cxx \
-            --enable-python \
+            --disable-python \
             --enable-csharp \
             --disable-java \
 
 make
+# No make check :-(
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,15 +10,8 @@ source:
         - CharScanner.patch
 
 build:
-    number: 1
+    number: 2
     skip: True  # [win]
-    skip: True  # [py3k]
-
-requirements:
-    build:
-        - python
-    run:
-        - python
 
 test:
     commands:
@@ -27,7 +20,7 @@ test:
 about:
     home: http://www.antlr2.org/
     license: BSD-3-clause and GPL-3.0 and Public Domain
-    summary: ANother Tool for Language Recognition (ANTLR)
+    summary: 'ANother Tool for Language Recognition (ANTLR).'
 
 extra:
     recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,8 @@ build:
 test:
     commands:
         - antlr-config --version
-
+        - conda inspect linkages -n _test antlr  # [linux]
+        - conda inspect objects -n _test antlr  # [osx]
 about:
     home: http://www.antlr2.org/
     license: BSD-3-clause and GPL-3.0 and Public Domain


### PR DESCRIPTION
@msarahan I had to downgrade `conda-build` here from `1.21.11` to `1.21.9` b/c of

``` shell
source tree in: /Users/travis/miniconda3/conda-bld/work/antlr-2.7.7
+ source activate /Users/travis/miniconda3/envs/_build_placehold_placehold_placehold_placehold_pla
/Users/travis/miniconda3/conda-bld/work/antlr-2.7.7/conda_build.sh: line 1: activate: No such file or directory
Command failed: /bin/bash -x -e /Users/travis/miniconda3/conda-bld/work/antlr-2.7.7/conda_build.sh
```

See https://travis-ci.org/ocefpaf/antlr-feedstock/builds/150667965#L377

Not sure if that is a bug or if something that I don't understand changed.
