### PR TITLE
Rebuild to get aarch64 and others for v4.9.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.11.1" %}
+{% set version = "4.9.3" %}
 
 # sometimes part of the tag name (with the hyphen separator).
 # however, this has changed without warning (with a different sha256) in the past...
@@ -12,10 +12,10 @@ package:
 
 source:
   url: https://github.com/antlr/antlr{{ version[0] }}/archive/{{ version }}.tar.gz
-  sha256: 81f87f03bb83b48da62e4fc8bfdaf447efb9fb3b7f19eb5cbc37f64e171218cf
+  sha256: efe4057d75ab48145d4683100fec7f77d7f87fa258707330cadd1f8e6f7eecae
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
# NOT FOR MERGING INTO MAIN

I'm trying to build omegaconf for aarch64, and it [depends on](https://github.com/conda-forge/omegaconf-feedstock/blob/7496ad323cde8d70726266addb9e14e4e5ac1c1c/recipe/meta.yaml#L31) antlr 4.9. Thus I'd like to rebuild v4.9.3 with the recent arch migration.

Would one of the maintainers be willing to create a `v4.9.3` branch to receive this commit?


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
