### PR TITLE
[ci skip] [skip ci] ***NO_CI*** Add antlr2 to abi migration branches

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -13,5 +13,6 @@ bot:
   abi_migration_branches:
   - v4.9.3
   - osx-arm64-4.8
+  - antlr2
 conda_build:
   pkg_format: '2'


### PR DESCRIPTION
In https://github.com/conda-forge/antlr-feedstock/pull/53#issuecomment-1360719938, we discussed that the antlr2 branch should be added to the abi migration branches in `main`, however, I forgot to follow through at the time. This PR aims to correct that.